### PR TITLE
Add missing return values

### DIFF
--- a/include/beam.h
+++ b/include/beam.h
@@ -267,7 +267,7 @@ public:
     double length(){return length_;}
     bool bunched(){return true;}
     bool corr(){return v_x_corr_;}
-    bool set_corr(bool corr = true){v_x_corr_ = corr;}
+    bool set_corr(bool corr = true){v_x_corr_ = corr; return corr;}
     void set_buffer(int n) {buffer_ = n;}
     void set_s(int s) {s_ = s;}
     void set_binary(bool b) {binary_ = b;}

--- a/include/dynamic.h
+++ b/include/dynamic.h
@@ -35,7 +35,7 @@ class Luminosity {
 public:
     void set_distance(double dx, double dy){dx_=dx; dy_=dy;}
     void set_freq(double f){freq_=f;}
-    bool set_use_ion_emit(bool b){use_ion_emittance_ = b;}
+    bool set_use_ion_emit(bool b){use_ion_emittance_ = b; return b;}
     void set_geo_emit(double emit_x, double emit_y, int i);
     void set_beam_size(double sigma_x, double sigma_y, int i);
     void set_particle_number(double n, int i);
@@ -84,7 +84,7 @@ class DynamicParas{
     int set_fixed_bunch_length(bool b){fixed_bunch_length_ = b; return 0;}
     int set_reset_time(bool b){reset_time_ = b; return 0;}
     int set_overwrite(bool b) {overwrite_ = b; return 0;}
-    int set_calc_lum(bool b) {calc_luminosity_ = b;}
+    int set_calc_lum(bool b) {calc_luminosity_ = b; return 0;}
     string output_file(){return filename_;}
     DynamicParas(double time, int n_step):time_(time),n_step_(n_step){dt_ = time_/n_step_;}
     DynamicParas(double time, int n_step, bool ibs, bool ecool):

--- a/src/ibs.cc
+++ b/src/ibs.cc
@@ -520,4 +520,5 @@ int ibs_rate(Lattice &lattice, Beam &beam, IBSParas &ibs_paras,double &rx, doubl
             assert(false&&"IBS model NOT exists!");
         }
     }
+    return 0;
 }


### PR DESCRIPTION
Fixed missing return values to prevent infinite loops or segmentation faults (SEGV) with gcc version 8.