### PR TITLE
Bug fixes and optimizations for IBS, also some OOP refactoring

### DIFF
--- a/include/beam.h
+++ b/include/beam.h
@@ -137,7 +137,7 @@ class UniformHollowBunch: public EBeamShape {
     double length(){return length_;}
     bool bunched(){return true;}
     UniformHollowBunch(double current, double in_radius, double out_radius, double length, double neutralisation=2):current_(current),
-        in_radius_(in_radius), out_radius_(out_radius),length_(length), neutralisation_(neutralisation){};
+        in_radius_(in_radius), out_radius_(out_radius), neutralisation_(neutralisation), length_(length) {}
 };
 
 class GaussianBunch: public EBeamShape{
@@ -267,7 +267,7 @@ public:
     double length(){return length_;}
     bool bunched(){return true;}
     bool corr(){return v_x_corr_;}
-    bool set_corr(bool corr = true){v_x_corr_ = corr;}
+    void set_corr(bool corr = true){v_x_corr_ = corr;}
     void set_buffer(int n) {buffer_ = n;}
     void set_s(int s) {s_ = s;}
     void set_binary(bool b) {binary_ = b;}

--- a/include/beam.h
+++ b/include/beam.h
@@ -36,23 +36,23 @@ public:
     int set_sigma_s(double x){sigma_s_ = x; return 0;}
     int set_center(double cx, double cy, double cz){center_[0] = cx; center_[1] = cy; center_[2] = cz; return 0;}
     int set_center(int i, double x);
-    int charge_number(){return charge_number_;}
-    double mass(){return mass_;}
-    double kinetic_energy(){return kinetic_energy_;}
-    double beta(){return beta_;}
-    double gamma(){return gamma_;}
-    double emit_nx(){return emit_nx_;}
-    double emit_ny(){return emit_ny_;}
-    double emit_x(){return emit_x_;}
-    double emit_y(){return emit_y_;}
-    double dp_p(){return dp_p_;}
-    double energy_spread(){return energy_spread_;}
-    double sigma_s(){return sigma_s_;}
-    double r(){return r_;}
-    double particle_number(){return particle_number_;}
-    double mass_number(){return mass_number_;}
-    double mass_J(){return mass_*1e6*k_e;}
-    bool bunched(){return bunched_;}
+    int charge_number() const {return charge_number_;}
+    double mass() const {return mass_;}
+    double kinetic_energy() const {return kinetic_energy_;}
+    double beta() const {return beta_;}
+    double gamma() const {return gamma_;}
+    double emit_nx() const {return emit_nx_;}
+    double emit_ny() const {return emit_ny_;}
+    double emit_x() const {return emit_x_;}
+    double emit_y() const {return emit_y_;}
+    double dp_p() const {return dp_p_;}
+    double energy_spread() const {return energy_spread_;}
+    double sigma_s() const {return sigma_s_;}
+    double r() const {return r_;}
+    double particle_number() const {return particle_number_;}
+    double mass_number() const {return mass_number_;}
+    double mass_J() const {return mass_*1e6*k_e;}
+    bool bunched()const {return bunched_;}
     int center(double &cx, double &cy, double &cz){cx = center_[0]; cy = center_[1]; cz = center_[2]; return 0;}
     double center(int i){ if (i<3) return center_[i]; else perror("Error index for electron beam center!"); return 1.0;}
     Beam(int charge_number, double mass_number, double kinetic_energy, double emit_nx, double emit_ny, double dp_p,

--- a/include/dynamic.h
+++ b/include/dynamic.h
@@ -35,7 +35,7 @@ class Luminosity {
 public:
     void set_distance(double dx, double dy){dx_=dx; dy_=dy;}
     void set_freq(double f){freq_=f;}
-    bool set_use_ion_emit(bool b){use_ion_emittance_ = b;}
+    void set_use_ion_emit(bool b){use_ion_emittance_ = b;}
     void set_geo_emit(double emit_x, double emit_y, int i);
     void set_beam_size(double sigma_x, double sigma_y, int i);
     void set_particle_number(double n, int i);
@@ -76,15 +76,15 @@ class DynamicParas{
     int n_sample(){return n_sample_;}
 //    int n_sample() {assert(model_==DynamicModel::MODEL_BEAM); return n_sample_;};
     DynamicModel model(){return model_;}
-    int set_model(DynamicModel model){model_ = model; return 0;}
-    int set_ion_save(int x){ion_save_intvl_ = x; return 0;}
-    int set_output_file(string filename){filename_ = filename; return 0;}
-    int set_output_intvl(int x){output_intvl_ = x; return 0;}
-    int set_n_sample(int x){n_sample_ = x; return 0;}
-    int set_fixed_bunch_length(bool b){fixed_bunch_length_ = b; return 0;}
-    int set_reset_time(bool b){reset_time_ = b; return 0;}
-    int set_overwrite(bool b) {overwrite_ = b; return 0;}
-    int set_calc_lum(bool b) {calc_luminosity_ = b;}
+    void set_model(DynamicModel model){model_ = model; }
+    void set_ion_save(int x){ion_save_intvl_ = x; }
+    void set_output_file(string filename){filename_ = filename; }
+    void set_output_intvl(int x){output_intvl_ = x; }
+    void set_n_sample(int x){n_sample_ = x; }
+    void set_fixed_bunch_length(bool b){fixed_bunch_length_ = b; }
+    void set_reset_time(bool b){reset_time_ = b; }
+    void set_overwrite(bool b) {overwrite_ = b; }
+    void set_calc_lum(bool b) {calc_luminosity_ = b; }
     string output_file(){return filename_;}
     DynamicParas(double time, int n_step):time_(time),n_step_(n_step){dt_ = time_/n_step_;}
     DynamicParas(double time, int n_step, bool ibs, bool ecool):

--- a/include/ibs.h
+++ b/include/ibs.h
@@ -3,6 +3,7 @@
 
 #include <assert.h>
 #include <memory>
+#include <vector>
 
 class Lattice;
 class Beam;
@@ -37,18 +38,16 @@ private:
     int nz_ = 0;                //Grid number in z direction.
     
     // Scratch variables for IBS calculation (Martini model)
-    std::unique_ptr<double []> sigma_xbet, sigma_xbetp, sigma_y, sigma_yp;
-    std::unique_ptr<double []> a_f, b2_f, c2_f, d2_f, dtld_f, k1_f, k2_f, k3_f;
+    std::vector<double> sigma_xbet, sigma_xbetp, sigma_y, sigma_yp;
+    std::vector<double> a_f, b2_f, c2_f, d2_f, dtld_f, k1_f, k2_f, k3_f;
 
-    std::unique_ptr<double []> sin_u, sin_u2, cos_u2, sin_v, cos_v, sin_u2_cos_v2;
-    std::unique_ptr<double []> g1, g2_1, g2_2, g3;
-    std::unique_ptr<double []> f1, f2, f3;
+    std::vector<double> sin_u, sin_u2, cos_u2, sin_v, cos_v, sin_u2_cos_v2;
+    std::vector<double> g1, g2_1, g2_2, g3;
+    std::vector<double> f1, f2, f3;
     
-    void set_bunch_size(int n);
     void bunch_size(const Lattice &lattice, const Beam &beam);
-    void set_abcdk(int n);
     void abcdk(const Lattice &lattice, const Beam &beam);
-    void coef_f(int nu, int nv);
+    void coef_f();
     void f(int n_element);
     double coef_a(const Lattice &lattice, const Beam &beam) const;
 public:

--- a/include/ibs.h
+++ b/include/ibs.h
@@ -14,17 +14,15 @@ class IBSSolver {
 protected:
     double log_c_ = 0.0;     //Coulomb logarithm.
     double k_ = 0.0;          //Coupling rate in transverse directions.
-    bool reset_ = true;
+    bool cacheInvalid = true;
     
     void ibs_coupling(double &rx, double &ry, double k, double emit_x, double emit_y);
 public:
     double log_c() const { return log_c_; }
     double k() const { return k_; }
-    bool reset() const { return reset_; }
     void set_k(double x) { k_ = x; }
     void set_log_c(double x) { log_c_ = x; }
-    void reset_off() { reset_ = false; }
-    void reset_on() { reset_ = true; }
+    void invalidateCache() { cacheInvalid = true; }
 
     IBSSolver(double log_c, double k);
     
@@ -33,30 +31,57 @@ public:
 
 class IBSSolver_Martini : public IBSSolver {
 private:
+    struct TrigonometryStorageUV {
+        double sin_u2_cos_v2;
+	double g1;
+	double g2_1;
+	double g2_2;
+    };
+    struct TrigonometryStorageV {
+        double sin_v;
+        double cos_v;
+    };
+    struct TrigonometryStorageU {
+        double sin_u;
+        double sin_u2;
+        double cos_u2;
+        double g3;
+        std::vector<TrigonometryStorageUV> uv;
+    };
+    struct OpticalStorage {
+        double a;
+	double b2;
+	double c2;
+	double d2;
+	double dtld;
+	double k1;
+	double k2;
+	double k3;
+    };
+    
     int nu_ = 0;                //Grid number in u direction.
     int nv_ = 0;                //Grid number in v direction.
     int nz_ = 0;                //Grid number in z direction.
     
     // Scratch variables for IBS calculation (Martini model)
     std::vector<double> sigma_xbet, sigma_xbetp, sigma_y, sigma_yp;
-    std::vector<double> a_f, b2_f, c2_f, d2_f, dtld_f, k1_f, k2_f, k3_f;
-
-    std::vector<double> sin_u, sin_u2, cos_u2, sin_v, cos_v, sin_u2_cos_v2;
-    std::vector<double> g1, g2_1, g2_2, g3;
+    std::vector<TrigonometryStorageU> storageU;
+    std::vector<TrigonometryStorageV> storageV;
+    std::vector<OpticalStorage> storageOpt;
     std::vector<double> f1, f2, f3;
     
     void bunch_size(const Lattice &lattice, const Beam &beam);
     void abcdk(const Lattice &lattice, const Beam &beam);
     void coef_f();
-    void f(int n_element);
+    void f();
     double coef_a(const Lattice &lattice, const Beam &beam) const;
 public:
     int nu() const { return nu_; }
     int nv() const { return nv_; }
     int nz() const { return nz_; }
-    void set_nu(int nu) { assert(nu>0&&"Wrong value of nu in IBS parameters!"); nu_ = nu; }
-    void set_nv(int nv) { assert(nv>0&&"Wrong value of nv in IBS parameters!"); nv_ = nv; }
-    void set_nz(int nz) { assert(nz>0&&"Wrong value of nz in IBS parameters!"); nz_ = nz; }
+    void set_nu(int nu) { assert(nu>0&&"Wrong value of nu in IBS parameters!"); nu_ = nu; invalidateCache(); }
+    void set_nv(int nv) { assert(nv>0&&"Wrong value of nv in IBS parameters!"); nv_ = nv; invalidateCache(); }
+    void set_nz(int nz) { assert(nz>0&&"Wrong value of nz in IBS parameters!"); nz_ = nz; invalidateCache(); }
     IBSSolver_Martini(int nu, int nv, int nz, double log_c, double k);
     virtual void rate(const Lattice &lattice, const Beam &beam, double &rx, double &ry, double &rs);
 };

--- a/include/ibs.h
+++ b/include/ibs.h
@@ -11,18 +11,12 @@ enum class IBSModel {MARTINI, BM};
 
 class IBSSolver {
 protected:
-    int nu_ = 0;                //Grid number in u direction.
-    int nv_ = 0;                //Grid number in v direction.
-    int nz_ = 0;                //Grid number in z direction.
     double log_c_ = 0.0;     //Coulomb logarithm.
     double k_ = 0.0;          //Coupling rate in transverse directions.
     bool reset_ = true;
     
     void ibs_coupling(double &rx, double &ry, double k, double emit_x, double emit_y);
 public:
-    int nu() const { return nu_; }
-    int nv() const { return nv_; }
-    int nz() const { return nz_; }
     double log_c() const { return log_c_; }
     double k() const { return k_; }
     bool reset() const { return reset_; }
@@ -30,17 +24,18 @@ public:
     void set_log_c(double x) { log_c_ = x; }
     void reset_off() { reset_ = false; }
     void reset_on() { reset_ = true; }
-    void set_nu(int nu) { assert(nu>0&&"Wrong value of nu in IBS parameters!"); nu_ = nu; }
-    void set_nv(int nv) { assert(nv>0&&"Wrong value of nv in IBS parameters!"); nv_ = nv; }
-    void set_nz(int nz) { assert(nz>0&&"Wrong value of nz in IBS parameters!"); nz_ = nz; }
 
-    IBSSolver(int nu, int nv, int nz, double log_c, double k);
+    IBSSolver(double log_c, double k);
     
     virtual void rate(const Lattice &lattice, const Beam &beam, double &rx, double &ry, double &rs) = 0;
 };
 
 class IBSSolver_Martini : public IBSSolver {
 private:
+    int nu_ = 0;                //Grid number in u direction.
+    int nv_ = 0;                //Grid number in v direction.
+    int nz_ = 0;                //Grid number in z direction.
+    
     // Scratch variables for IBS calculation (Martini model)
     std::unique_ptr<double []> sigma_xbet, sigma_xbetp, sigma_y, sigma_yp;
     std::unique_ptr<double []> a_f, b2_f, c2_f, d2_f, dtld_f, k1_f, k2_f, k3_f;
@@ -57,6 +52,12 @@ private:
     void f(int n_element);
     double coef_a(const Lattice &lattice, const Beam &beam) const;
 public:
+    int nu() const { return nu_; }
+    int nv() const { return nv_; }
+    int nz() const { return nz_; }
+    void set_nu(int nu) { assert(nu>0&&"Wrong value of nu in IBS parameters!"); nu_ = nu; }
+    void set_nv(int nv) { assert(nv>0&&"Wrong value of nv in IBS parameters!"); nv_ = nv; }
+    void set_nz(int nz) { assert(nz>0&&"Wrong value of nz in IBS parameters!"); nz_ = nz; }
     IBSSolver_Martini(int nu, int nv, int nz, double log_c, double k);
     virtual void rate(const Lattice &lattice, const Beam &beam, double &rx, double &ry, double &rs);
 };

--- a/include/ibs.h
+++ b/include/ibs.h
@@ -36,13 +36,13 @@ public:
     void set_nz(int nz){assert(nz>0&&"Wrong value of nz in IBS parameters!"); nz_ = nz;}
     IBSModel model() {return model_;}
 
-    IBSParas(int nu, int nv):nu_(nu),nv_(nv){};
-    IBSParas(int nu, int nv, double log_c):nu_(nu),nv_(nv),log_c_(log_c){};
-    IBSParas(int nu, int nv, int nz):nu_(nu),nv_(nv),nz_(nz){use_log_c_ = false;}
-    IBSParas(IBSModel model):model_(model){};
+    IBSParas(int nu, int nv):nu_(nu),nv_(nv) { }
+    IBSParas(int nu, int nv, double log_c):nu_(nu),nv_(nv),log_c_(log_c) { }
+    IBSParas(int nu, int nv, int nz):nu_(nu),nv_(nv),nz_(nz) { use_log_c_ = false; }
+    IBSParas(IBSModel model):model_(model) { }
 };
 
-int ibs_rate(Lattice &lattice, Beam &beam, IBSParas &ibs_paras,double &rx, double &ry, double &rs);
+void ibs_rate(Lattice &lattice, Beam &beam, IBSParas &ibs_paras,double &rx, double &ry, double &rs);
 
 
 #endif

--- a/include/ibs.h
+++ b/include/ibs.h
@@ -1,48 +1,85 @@
 #ifndef IBS_HPP
 #define IBS_HPP
 
-#include "ring.h"
 #include <assert.h>
-#include <cmath>
-#include <cstring>
-#include <iostream>
+#include <memory>
+
+class Lattice;
+class Beam;
 
 enum class IBSModel {MARTINI, BM};
 
-class IBSParas{
+class IBSSolver {
+protected:
     int nu_ = 0;                //Grid number in u direction.
     int nv_ = 0;                //Grid number in v direction.
     int nz_ = 0;                //Grid number in z direction.
-    double log_c_ = 20;     //Coulomb logarithm.
-    double k_ = 0;          //Coupling rate in transverse directions.
-    bool use_log_c_ = true;
+    double log_c_ = 0.0;     //Coulomb logarithm.
+    double k_ = 0.0;          //Coupling rate in transverse directions.
     bool reset_ = true;
-    IBSModel model_ = IBSModel::MARTINI;
+    
+    void ibs_coupling(double &rx, double &ry, double k, double emit_x, double emit_y);
 public:
-    int nu(){return nu_;}
-    int nv(){return nv_;}
-    int nz(){return nz_;}
-    double log_c(){return log_c_;}
-    double k(){return k_;}
-    bool use_log_c(){return use_log_c_;}
-    bool reset(){return reset_;}
-    int set_k(double x){k_ = x; return 0;}
-    int set_log_c(double x){ log_c_ = x; use_log_c_ = true; return 0;}
-    int reset_off(){reset_ = false; return 0;}
-    int reset_on(){reset_ = true; return 0;}
-    void set_model(IBSModel model) {model_ = model;}
-    void set_nu(int nu){assert(nu>0&&"Wrong value of nu in IBS parameters!"); nu_ = nu;}
-    void set_nv(int nv){assert(nv>0&&"Wrong value of nv in IBS parameters!"); nv_ = nv;}
-    void set_nz(int nz){assert(nz>0&&"Wrong value of nz in IBS parameters!"); nz_ = nz;}
-    IBSModel model() {return model_;}
+    int nu() const { return nu_; }
+    int nv() const { return nv_; }
+    int nz() const { return nz_; }
+    double log_c() const { return log_c_; }
+    double k() const { return k_; }
+    bool reset() const { return reset_; }
+    void set_k(double x) { k_ = x; }
+    void set_log_c(double x) { log_c_ = x; }
+    void reset_off() { reset_ = false; }
+    void reset_on() { reset_ = true; }
+    void set_nu(int nu) { assert(nu>0&&"Wrong value of nu in IBS parameters!"); nu_ = nu; }
+    void set_nv(int nv) { assert(nv>0&&"Wrong value of nv in IBS parameters!"); nv_ = nv; }
+    void set_nz(int nz) { assert(nz>0&&"Wrong value of nz in IBS parameters!"); nz_ = nz; }
 
-    IBSParas(int nu, int nv):nu_(nu),nv_(nv) { }
-    IBSParas(int nu, int nv, double log_c):nu_(nu),nv_(nv),log_c_(log_c) { }
-    IBSParas(int nu, int nv, int nz):nu_(nu),nv_(nv),nz_(nz) { use_log_c_ = false; }
-    IBSParas(IBSModel model):model_(model) { }
+    IBSSolver(int nu, int nv, int nz, double log_c, double k);
+    
+    virtual void rate(const Lattice &lattice, const Beam &beam, double &rx, double &ry, double &rs) = 0;
 };
 
-void ibs_rate(Lattice &lattice, Beam &beam, IBSParas &ibs_paras,double &rx, double &ry, double &rs);
+class IBSSolver_Martini : public IBSSolver {
+private:
+    // Scratch variables for IBS calculation (Martini model)
+    std::unique_ptr<double []> sigma_xbet, sigma_xbetp, sigma_y, sigma_yp;
+    std::unique_ptr<double []> a_f, b2_f, c2_f, d2_f, dtld_f, k1_f, k2_f, k3_f;
 
+    std::unique_ptr<double []> sin_u, sin_u2, cos_u2, sin_v, cos_v, sin_u2_cos_v2;
+    std::unique_ptr<double []> g1, g2_1, g2_2, g3;
+    std::unique_ptr<double []> f1, f2, f3;
+    
+    void set_bunch_size(int n);
+    void bunch_size(const Lattice &lattice, const Beam &beam);
+    void set_abcdk(int n);
+    void abcdk(const Lattice &lattice, const Beam &beam);
+    void coef_f(int nu, int nv);
+    void f(int n_element);
+    double coef_a(const Lattice &lattice, const Beam &beam) const;
+public:
+    IBSSolver_Martini(int nu, int nv, int nz, double log_c, double k);
+    virtual void rate(const Lattice &lattice, const Beam &beam, double &rx, double &ry, double &rs);
+};
+
+// IBS calculation by Bjorken-Mtingwa model using Sergei Nagaitsev's method
+class IBSSolver_BM : public IBSSolver {
+private:
+    std::unique_ptr<double []> phi;
+    std::unique_ptr<double []> dx2; //D_x * D_x
+    std::unique_ptr<double []> dx_betax_phi_2; // D_x * D_x / (beta_x * beta_x) + phi * phi
+    std::unique_ptr<double []> sqrt_betay;  // sqrt(beta_y)
+    std::unique_ptr<double []> gamma_phi_2; // gamma * gamma * phi * phi
+    std::unique_ptr<double []> psi;
+    std::unique_ptr<double []> sx, sp, sxp;
+    std::unique_ptr<double []> inv_sigma;
+
+    void alloc_var(std::unique_ptr<double []>& ptr, int n);
+    void init_fixed_var(const Lattice &lattice, const Beam &beam);
+    void calc_kernels(const Lattice &lattice, const Beam &beam);
+    double coef_bm(const Lattice &lattice, const Beam &beam) const;
+public:
+    IBSSolver_BM(double log_c, double k);
+    virtual void rate(const Lattice &lattice, const Beam &beam, double &rx, double &ry, double &rs);
+};
 
 #endif

--- a/include/ring.h
+++ b/include/ring.h
@@ -29,20 +29,20 @@ class Lattice{
     int n_element_;
     double circ_;
  public:
-    double s(int i){return s_.at(i);}
-    double betx(int i){return betx_.at(i);}
-    double alfx(int i){return alfx_.at(i);}
-    double mux(int i){return mux_.at(i);}
-    double dx(int i){return dx_.at(i);}
-    double dpx(int i){return dpx_.at(i);}
-    double bety(int i){return bety_.at(i);}
-    double alfy(int i){return alfy_.at(i);}
-    double muy(int i){return muy_.at(i);}
-    double dy(int i){return dy_.at(i);}
-    double dpy(int i){return dpy_.at(i);}
-    int n_element(){return n_element_;}
-    double l_element(int i){return l_element_.at(i);}
-    double circ(){return circ_;}
+    double s(int i) const {return s_.at(i);}
+    double betx(int i) const {return betx_.at(i);}
+    double alfx(int i) const {return alfx_.at(i);}
+    double mux(int i) const {return mux_.at(i);}
+    double dx(int i) const {return dx_.at(i);}
+    double dpx(int i) const {return dpx_.at(i);}
+    double bety(int i) const {return bety_.at(i);}
+    double alfy(int i) const {return alfy_.at(i);}
+    double muy(int i) const {return muy_.at(i);}
+    double dy(int i) const {return dy_.at(i);}
+    double dpy(int i) const {return dpy_.at(i);}
+    int n_element() const {return n_element_;}
+    double l_element(int i) const {return l_element_.at(i);}
+    double circ() const {return circ_;}
     Lattice(std::string filename);
 
 };

--- a/src/arbitrary_electron_beam.cc
+++ b/src/arbitrary_electron_beam.cc
@@ -828,7 +828,8 @@ void density(vector<Box> &tree, std::vector<unsigned long int>& list_e, std::vec
             int n_e = box.n_ptcl;
             double d = n_e/(box_size*box_size*box_size); //density
             unsigned long int idx = box.first_ptcl;
-            double vx_avg, vy_avg, vz_avg;
+//            double vx_avg, vy_avg, vz_avg;
+            double vz_avg;
             vz_avg = 0;
             while(list_e.at(idx)!=ne) {
                 vz_avg += vz.at(idx);
@@ -837,8 +838,7 @@ void density(vector<Box> &tree, std::vector<unsigned long int>& list_e, std::vec
             vz_avg /= n_e;
 
             idx = box.first_ptcl;
-            double vx_rms, vy_rms, vz_rms;
-            vz_rms = 0;
+            double vx_rms = 0, vy_rms = 0, vz_rms = 0;
             while(list_e.at(idx)!=ne) {
                 double dvz = vz.at(idx) - vz_avg;
                 vx_rms += vx.at(idx)*vx.at(idx);

--- a/src/dynamic.cc
+++ b/src/dynamic.cc
@@ -1,12 +1,13 @@
 #include "dynamic.h"
 #include <chrono>
+#include <cmath>
 #include "constants.h"
 #include "functions.h"
 #include "particle_model.h"
 #include "turn_by_turn.h"
 
 DynamicParas *dynamic_paras = nullptr;
-IBSParas *ibs_paras = nullptr;
+IBSSolver *ibs_solver = nullptr;
 EcoolRateParas *ecool_paras = nullptr;
 ForceParas *force_paras = nullptr;
 Luminosity *luminosity_paras = nullptr;
@@ -441,7 +442,10 @@ int dynamic(Beam &ion, Cooler &cooler, EBeam &ebeam, Ring &ring) {
         if (ion.bunched()) emit.at(3) = ion.sigma_s();
 
         //Rate calculation
-        if(ibs) ibs_rate(*ring.lattice_, ion, *ibs_paras, r_ibs.at(0), r_ibs.at(1), r_ibs.at(2));
+        if(ibs) {
+            assert(ibs_solver != nullptr);
+            ibs_solver->rate(*ring.lattice_, ion, r_ibs.at(0), r_ibs.at(1), r_ibs.at(2));
+        }
         if(ecool) {
             ecooling_rate(*ecool_paras, *force_paras, ion, cooler, ebeam, ring, r_ecool.at(0), r_ecool.at(1), r_ecool.at(2));
         }

--- a/src/ibs.cc
+++ b/src/ibs.cc
@@ -7,8 +7,8 @@
 #include "ring.h"
 #include "beam.h"
 
-IBSSolver::IBSSolver(int nu, int nv, int nz, double log_c, double k)
-    : nu_(nu), nv_(nv), nz_(nz), log_c_(log_c), k_(k)
+IBSSolver::IBSSolver(double log_c, double k)
+    : log_c_(log_c), k_(k)
 {
 }
 
@@ -22,8 +22,11 @@ void IBSSolver::ibs_coupling(double &rx, double &ry, double k, double emit_x, do
 
 
 IBSSolver_Martini::IBSSolver_Martini(int nu, int nv, int nz, double log_c, double k)
-    : IBSSolver(nu, nv, nz, log_c, k)
+    : IBSSolver(log_c, k), nu_(nu), nv_(nv), nz_(nz)
 {
+#ifndef NDEBUG
+	std::cerr << "DEBUG: ISBSolver_Martini constructor" << std::endl;
+#endif
 }
 
 //Set ptrs for bunch_size
@@ -143,6 +146,9 @@ void IBSSolver_Martini::abcdk(const Lattice &lattice, const Beam &beam)
 
 void IBSSolver_Martini::coef_f(int nu, int nv)
 {
+#ifndef NDEBUG
+	std::cerr << "ISBSolver_Martini::coef_f()" << std::endl;
+#endif
     if(sin_u.get()==nullptr) sin_u.reset(new double[nu]);
     if(sin_u2.get()==nullptr) sin_u2.reset(new double[nu]);
     if(cos_u2.get()==nullptr) cos_u2.reset(new double[nu]);
@@ -196,8 +202,9 @@ void IBSSolver_Martini::f(int n_element)
 
 if (log_c_ > 0) {
     double duvTimes2Logc = 2*k_pi*k_pi/(nu_*nv_) * 2 * log_c_;
-
-
+#ifndef NDEBUG
+	std::cerr << "ISBSolver_Martini::f(): using log_c" << std::endl;
+#endif
 //    #pragma omp parallel for
     for(int ie=0; ie<n_element; ++ie){
         const double tmp_a_f = a_f[ie];
@@ -228,6 +235,9 @@ if (log_c_ > 0) {
         f3[ie] *= k3_f[ie] * duvTimes2Logc;
     }
 } else {
+#ifndef NDEBUG
+	std::cerr << "ISBSolver_Martini::f(): using nz" << std::endl;
+#endif
     for(int ie=0; ie<n_element; ++ie){
         int cnt = 0;
         double duv = 2*k_pi*k_pi/(nv_*nu_);
@@ -302,6 +312,15 @@ void IBSSolver_Martini::rate(const Lattice &lattice, const Beam &beam, double &r
     if(k_>0) ibs_coupling(rx, ry, k_, beam.emit_nx(), beam.emit_ny());
 }
 
+
+
+IBSSolver_BM::IBSSolver_BM(double log_c, double k)
+    : IBSSolver(log_c, k)
+{
+#ifndef NDEBUG
+	std::cerr << "DEBUG: ISBSolver_BM constructor" << std::endl;
+#endif
+}
 
 void IBSSolver_BM::alloc_var(std::unique_ptr<double []>& ptr, int n) {
     if(ptr.get()==nullptr) {

--- a/src/ibs.cc
+++ b/src/ibs.cc
@@ -29,33 +29,19 @@ IBSSolver_Martini::IBSSolver_Martini(int nu, int nv, int nz, double log_c, doubl
 #endif
 }
 
-//Set ptrs for bunch_size
-void IBSSolver_Martini::set_bunch_size(int n) {
-    if(sigma_xbet.get()==nullptr) {
-        sigma_xbet.reset(new double[n]);
-        memset(sigma_xbet.get(), 0, n*sizeof(double));
-//        std::cout<<"reset bunch_sizze"<<std::endl;
-    }
-    if(sigma_xbetp.get()==nullptr) {
-        sigma_xbetp.reset(new double[n]);
-        memset(sigma_xbetp.get(), 0, n*sizeof(double));
-    }
-    if(sigma_y.get()==nullptr) {
-        sigma_y.reset(new double[n]);
-        memset(sigma_y.get(), 0, n*sizeof(double));
-    }
-    if(sigma_yp.get()==nullptr) {
-        sigma_yp.reset(new double[n]);
-        memset(sigma_yp.get(), 0, n*sizeof(double));
-    }
-}
-
 //Calculate sigma_xbet, sigma_xbetp, sigma_y, sigma_yp
-void IBSSolver_Martini::bunch_size(const Lattice &lattice, const Beam &beam) {
+void IBSSolver_Martini::bunch_size(const Lattice &lattice, const Beam &beam)
+{
+    int n = lattice.n_element();
+    
+    sigma_xbet.reserve(n);
+    sigma_xbetp.reserve(n);
+    sigma_y.reserve(n);
+    sigma_yp.reserve(n);
+    
     double emit_x = beam.emit_x();
     double emit_y = beam.emit_y();
-    set_bunch_size(lattice.n_element());
-    for(int i=0; i<lattice.n_element(); ++i) {
+    for(int i=0; i<n; ++i) {
         sigma_xbet[i] = sqrt(lattice.betx(i)*emit_x);
         sigma_y[i] = sqrt(lattice.bety(i)*emit_y);
         double alf2 = lattice.alfx(i);
@@ -67,43 +53,6 @@ void IBSSolver_Martini::bunch_size(const Lattice &lattice, const Beam &beam) {
     }
 }
 
-//Set the ptrs for abcdk
-void IBSSolver_Martini::set_abcdk(int n) {
-    if(a_f.get()==nullptr) {
-        a_f.reset(new double[n]);
-        memset(a_f.get(), 0, n*sizeof(double));
-//        std::cout<<"reset abcdk"<<std::endl;
-    }
-    if(b2_f.get()==nullptr) {
-        b2_f.reset(new double[n]);
-        memset(b2_f.get(), 0, n*sizeof(double));
-    }
-    if(c2_f.get()==nullptr) {
-        c2_f.reset(new double[n]);
-        memset(c2_f.get(), 0, n*sizeof(double));
-    }
-    if(d2_f.get()==nullptr) {
-        d2_f.reset(new double[n]);
-        memset(d2_f.get(), 0, n*sizeof(double));
-    }
-    if(dtld_f.get()==nullptr) {
-        dtld_f.reset(new double[n]);
-        memset(dtld_f.get(), 0, n*sizeof(double));
-    }
-    if(k1_f.get()==nullptr) {
-        k1_f.reset(new double[n]);
-        memset(k1_f.get(), 0, n*sizeof(double));
-    }
-    if(k2_f.get()==nullptr) {
-        k2_f.reset(new double[n]);
-        memset(k2_f.get(), 0, n*sizeof(double));
-    }
-    if(k3_f.get()==nullptr) {
-        k3_f.reset(new double[n]);
-        memset(k3_f.get(), 0, n*sizeof(double));
-    }
-}
-
 //Calculate a, b, c, d and dtld
 //Call bunch_size() before calling this one
 void IBSSolver_Martini::abcdk(const Lattice &lattice, const Beam &beam)
@@ -111,7 +60,14 @@ void IBSSolver_Martini::abcdk(const Lattice &lattice, const Beam &beam)
     double d_tld, q, sigma_x, sigma_tmp;
     int n = lattice.n_element();
 
-    set_abcdk(n);
+    a_f.reserve(n);
+    b2_f.reserve(n);
+    c2_f.reserve(n);
+    d2_f.reserve(n);
+    dtld_f.reserve(n);
+    k1_f.reserve(n);
+    k2_f.reserve(n);
+    k3_f.reserve(n);
 
     double dp_p = beam.dp_p();
     double beta = beam.beta();
@@ -144,26 +100,25 @@ void IBSSolver_Martini::abcdk(const Lattice &lattice, const Beam &beam)
     }
 }
 
-void IBSSolver_Martini::coef_f(int nu, int nv)
+void IBSSolver_Martini::coef_f()
 {
 #ifndef NDEBUG
 	std::cerr << "ISBSolver_Martini::coef_f()" << std::endl;
 #endif
-    if(sin_u.get()==nullptr) sin_u.reset(new double[nu]);
-    if(sin_u2.get()==nullptr) sin_u2.reset(new double[nu]);
-    if(cos_u2.get()==nullptr) cos_u2.reset(new double[nu]);
-    if(sin_v.get()==nullptr) sin_v.reset(new double[nv]);
-    if(cos_v.get()==nullptr) cos_v.reset(new double[nv]);
-    if(sin_u2_cos_v2.get()==nullptr) sin_u2_cos_v2.reset(new double[nu*nv]);
-
-    if(g1.get()==nullptr) g1.reset(new double[nu*nv]);
-    if(g2_1.get()==nullptr) g2_1.reset(new double[nu*nv]);
-    if(g2_2.get()==nullptr) g2_2.reset(new double[nu*nv]);
-    if(g3.get()==nullptr) g3.reset(new double[nu]);
-
-    double du = k_pi/nu;
+    sin_u.reserve(nu_);
+    sin_u2.reserve(nu_);
+    cos_u2.reserve(nu_);
+    sin_v.reserve(nv_);
+    cos_v.reserve(nv_);
+    sin_u2_cos_v2.reserve(nu_ * nv_);
+    g1.reserve(nu_ * nv_);
+    g2_1.reserve(nu_ * nv_);
+    g2_2.reserve(nu_ * nv_);
+    g3.reserve(nu_);
+    
+    double du = k_pi/nu_;
     double u = -0.5*du;
-    for(int i=0; i<nu; ++i){
+    for(int i=0; i<nu_; ++i){
         u += du;
         sin_u[i] = sin(u);
         sin_u2[i] = sin_u[i]*sin_u[i];
@@ -171,17 +126,17 @@ void IBSSolver_Martini::coef_f(int nu, int nv)
         g3[i] = 1-3*cos_u2[i];
     }
 
-    double dv = 2*k_pi/nv;
+    double dv = 2*k_pi/nv_;
     double v = -0.5*dv;
-    for(int i=0; i<nv; ++i){
+    for(int i=0; i<nv_; ++i){
         v += dv;
         sin_v[i] = sin(v);
         cos_v[i] = cos(v);
     }
 
     int cnt = 0;
-    for(int i=0; i<nu; ++i){
-        for(int j=0; j<nv; ++j){
+    for(int i=0; i<nu_; ++i){
+        for(int j=0; j<nv_; ++j){
             sin_u2_cos_v2[cnt] = sin_u2[i]*cos_v[j]*cos_v[j];
             g1[cnt] = 1-3*sin_u2_cos_v2[cnt];
             g2_1[cnt] = 1-3*sin_u2[i]*sin_v[j]*sin_v[j];
@@ -193,14 +148,11 @@ void IBSSolver_Martini::coef_f(int nu, int nv)
 
 void IBSSolver_Martini::f(int n_element)
 {
-    if(f1.get()==nullptr) f1.reset(new double[n_element]);
-    if(f2.get()==nullptr) f2.reset(new double[n_element]);
-    if(f3.get()==nullptr) f3.reset(new double[n_element]);
-    memset(f1.get(), 0, n_element*sizeof(double));
-    memset(f2.get(), 0, n_element*sizeof(double));
-    memset(f3.get(), 0, n_element*sizeof(double));
+    f1.reserve(n_element);
+    f2.reserve(n_element);
+    f3.reserve(n_element);
 
-if (log_c_ > 0) {
+    if (log_c_ > 0) {
     double duvTimes2Logc = 2*k_pi*k_pi/(nu_*nv_) * 2 * log_c_;
 #ifndef NDEBUG
 	std::cerr << "ISBSolver_Martini::f(): using log_c" << std::endl;
@@ -239,7 +191,7 @@ if (log_c_ > 0) {
 	std::cerr << "ISBSolver_Martini::f(): using nz" << std::endl;
 #endif
     for(int ie=0; ie<n_element; ++ie){
-        int cnt = 0;
+/*        int cnt = 0;
         double duv = 2*k_pi*k_pi/(nv_*nu_);
         for(int iu=0; iu<nu_; ++iu){
             for(int iv=0; iv<nv_; ++iv){
@@ -262,7 +214,7 @@ if (log_c_ > 0) {
         f1[ie] *= k1_f[ie]*duv;
         f2[ie] *= k2_f[ie]*duv;
         f3[ie] *= k3_f[ie]*duv;
-    }
+*/    }
 }
 }
 
@@ -285,7 +237,7 @@ void IBSSolver_Martini::rate(const Lattice &lattice, const Beam &beam, double &r
     bunch_size(lattice, beam);
     abcdk(lattice, beam);
     if(reset()) {
-        coef_f(nu_, nv_);
+        coef_f();
         reset_off();
     }
     f(n_element);

--- a/src/main.cc
+++ b/src/main.cc
@@ -679,8 +679,8 @@ int main(int argc, char** argv) {
     }
 
     //Pause the system
-    std::cout<<std::endl<<"Press the Enter key to close the window."<<std::endl;
-    std::cin.ignore( std::numeric_limits< std::streamsize >::max( ), '\n' );
+//    std::cout<<std::endl<<"Press the Enter key to close the window."<<std::endl;
+//    std::cin.ignore( std::numeric_limits< std::streamsize >::max( ), '\n' );
 
     return 0;
 }

--- a/src/main.cc
+++ b/src/main.cc
@@ -2,6 +2,7 @@
 #include <chrono>
 #include <fstream>
 #include <map>
+#include <cmath>
 #include "dynamic.h"
 #include "ecooling.h"
 #include "ibs.h"
@@ -13,7 +14,7 @@
 using std::string;
 
 extern DynamicParas * dynamic_paras;
-extern IBSParas * ibs_paras;
+extern IBSSolver * ibs_solver;
 extern EcoolRateParas * ecool_paras;
 extern ForceParas * force_paras;
 extern Luminosity *luminosity_paras;
@@ -189,7 +190,7 @@ int main(int argc, char** argv) {
                 int nv = 100;
                 int nz = 40;
                 double log_c = 39.9/2;
-                ibs_paras = new IBSParas(nu, nv, log_c);
+                ibs_solver = new IBSSolver_Martini(nu, nv, nz, log_c, 0);
 
 //                //Calculate IBS rate.
 //
@@ -365,7 +366,7 @@ int main(int argc, char** argv) {
                 int nv = 100;
                 int nz = 40;
                 double log_c = 39.2/2;
-                IBSParas ibs_paras(nu, nv, nz);
+                ibs_solver = new IBSSolver_Martini(nu, nv, nz, log_c, 0);
 
 //                //Calculate IBS rate.
 //                std::chrono::steady_clock::time_point start, end;
@@ -380,13 +381,11 @@ int main(int argc, char** argv) {
 //
 //                std::cout<<rx_ibs<<' '<<ry_ibs<<' '<<rz_ibs<<std::endl;
 
-                ibs_paras.set_log_c(log_c);
-                ibs_rate(lattice, p_beam, ibs_paras, rx_ibs, ry_ibs, rz_ibs);
+                ibs_solver->rate(lattice, p_beam, rx_ibs, ry_ibs, rz_ibs);
                 std::cout<<rx_ibs<<' '<<ry_ibs<<' '<<rz_ibs<<std::endl;
 
-
-                ibs_paras.set_k(0.2);
-                ibs_rate(lattice, p_beam, ibs_paras, rx_ibs, ry_ibs, rz_ibs);
+                ibs_solver->set_k(0.2);
+                ibs_solver->rate(lattice, p_beam, rx_ibs, ry_ibs, rz_ibs);
                 std::cout<<rx_ibs<<' '<<ry_ibs<<' '<<rz_ibs<<std::endl;
                 break;
             }
@@ -416,7 +415,7 @@ int main(int argc, char** argv) {
                 int nv = 200;
                 int nz = 40;
                 double log_c = 39.9/2;
-                ibs_paras = new IBSParas(nu, nv, log_c);
+                ibs_solver = new IBSSolver_Martini(nu, nv, nz, log_c, 0);
 
                 dynamic_paras = new DynamicParas(3600, 360, true, false);
 
@@ -455,8 +454,7 @@ int main(int argc, char** argv) {
                 int nv = 200;
                 int nz = 40;
                 double log_c = 44.8/2;
-                ibs_paras = new IBSParas(nu, nv, log_c);
-                ibs_paras->set_k(1.0);
+                ibs_solver = new IBSSolver_Martini(nu, nv, nz, log_c, 1.0);
 
                 dynamic_paras = new DynamicParas(3600, 360, true, false);
 
@@ -630,12 +628,10 @@ int main(int argc, char** argv) {
                 int nz = 40;
                 double log_c = 40.4/2;      //100 GeV, 63.3 GeV CM Energy
     //            double log_c = 39.2/2;    //100 GeV
-                ibs_paras = new IBSParas(nu, nv, log_c);
-    //            ibs_paras = new IBSParas(nu, nv, nz);
-                ibs_paras->set_k(0.4);
+                ibs_solver = new IBSSolver_Martini(nu, nv, nz, log_c, 0.4);
 
                 double rx_ibs, ry_ibs, rz_ibs;
-                ibs_rate(lattice, p_beam, *ibs_paras, rx_ibs, ry_ibs, rz_ibs);
+                ibs_solver->rate(lattice, p_beam, rx_ibs, ry_ibs, rz_ibs);
                 std::cout<<"IBS rate: [1/s] "<<rx_ibs<<' '<<ry_ibs<<' '<<rz_ibs<<std::endl;
                 std::cout<<"Total rate: [1/s] "<<rx_ibs+rate_x<<' '<<ry_ibs+rate_y<<' '<<rz_ibs+rate_s<<std::endl<<std::endl;
 

--- a/src/particle_model.cc
+++ b/src/particle_model.cc
@@ -1,6 +1,6 @@
 #include "particle_model.h"
 #include <chrono>
-
+#include <cmath>
 #include "constants.h"
 #include "dynamic.h"
 #include "ecooling.h"

--- a/src/particle_model.cc
+++ b/src/particle_model.cc
@@ -12,7 +12,7 @@ extern std::unique_ptr<double []> x_bet, xp_bet, y_bet, yp_bet, ds, dp_p, x, y, 
 extern std::unique_ptr<double []> force_x, force_y, force_z;
 
 std::unique_ptr<double []> rdn;
-int n_sample = 0;
+unsigned int n_sample = 0;
 double p0 = 0;
 
 void initialize_particle_model(Beam &ion) {
@@ -64,16 +64,16 @@ void particle_model_ibs_scratches() {
     srand(time(NULL));
 }
 
-void ibs_kick(int n_sample, double rate, double twiss, double dt, double emit, double* p) {
+void ibs_kick(unsigned int n_sample, double rate, double twiss, double dt, double emit, double* p) {
 
     if (rate>0) {
         double theta = sqrt(2*rate*dt*emit/twiss);
         gaussian_random(n_sample, rdn.get(), 1, 0);
-        for(int i=0; i<n_sample; ++i) p[i] += theta*rdn[i];
+        for(unsigned int i=0; i<n_sample; ++i) p[i] += theta*rdn[i];
     }
     else {
         double k = exp(rate*dt);
-        for(int i=0; i<n_sample; ++i) p[i] *= k;
+        for(unsigned int i=0; i<n_sample; ++i) p[i] *= k;
     }
 }
 

--- a/src/ring.cc
+++ b/src/ring.cc
@@ -40,7 +40,7 @@ Lattice::Lattice(std::string filename) {
             start_reading = 0;
             iss >> name;
 //            iss >> keyword;
-            int cnt_keywords = 0;
+            unsigned int cnt_keywords = 0;
             int cnt_position = 0;
             while(cnt_keywords!=keywords.size()) {
                 iss >> keyword;

--- a/src/turn_by_turn.cc
+++ b/src/turn_by_turn.cc
@@ -1,6 +1,6 @@
 #include "turn_by_turn.h"
 #include <chrono>
-
+#include <cmath>
 #include "beam.h"
 #include "constants.h"
 #include "dynamic.h"

--- a/src/turn_by_turn.cc
+++ b/src/turn_by_turn.cc
@@ -15,7 +15,7 @@ extern std::unique_ptr<double []> x_bet, xp_bet, y_bet, yp_bet, ds, dp_p, x, y, 
 extern std::unique_ptr<double []> force_x, force_y, force_z;
 
 extern std::unique_ptr<double []> rdn;
-extern int n_sample;
+extern unsigned int n_sample;
 extern double p0;
 
 void initialize_turn_by_turn_model(Beam &ion, Ring &ring) {
@@ -57,19 +57,19 @@ void turn_by_turn_move_particles(Beam &ion, Ring &ring, Cooler &cooler) {
         yp_bet[i] = yp[i] - dpy*dp_p[i];
     }
     //one turn phase advance
-    double alf_x = dynamic_paras->twiss_ref.alf_x;
-    double alf_y = dynamic_paras->twiss_ref.alf_y;
-    double beta_x = dynamic_paras->twiss_ref.bet_x;
-    double beta_y = dynamic_paras->twiss_ref.bet_y;
+//    double alf_x = dynamic_paras->twiss_ref.alf_x;
+//    double alf_y = dynamic_paras->twiss_ref.alf_y;
+//    double beta_x = dynamic_paras->twiss_ref.bet_x;
+//    double beta_y = dynamic_paras->twiss_ref.bet_y;
 
-    double gamma_x = (1+alf_x*alf_x)/beta_x;
-    double gamma_y = (1+alf_y*alf_y)/beta_y;
+//    double gamma_x = (1+alf_x*alf_x)/beta_x;
+//    double gamma_y = (1+alf_y*alf_y)/beta_y;
 
     //Transverse motion by tunes
     assert(ring.tunes.qx>0&&ring.tunes.qy>0&&"Transverse tunes are needed for Turn_by_turn model");
     double Qx = ring.tunes.qx;
     double Qy = ring.tunes.qy;
-    for (auto i=0; i<n_sample; ++i) {
+    for (unsigned int i=0; i<n_sample; ++i) {
         double phi = 2*k_pi*Qx;
         double x_bet_0 = x_bet[i];
         double xp_bet_0 = xp_bet[i];
@@ -129,7 +129,7 @@ void turn_by_turn_move_particles(Beam &ion, Ring &ring, Cooler &cooler) {
             double phi = 2*k_pi*ring.tunes.qs;
             double inv_beta_s = 1/ring.beta_s();
             double beta_s = ring.beta_s();
-            for (auto i=0; i<n_sample; ++i) {
+            for (unsigned int i=0; i<n_sample; ++i) {
                 double dp_p_0 = dp_p[i];
                 double ds_0 = ds[i];
                 dp_p[i] = cos(phi)*dp_p_0 - sin(phi)*ds_0*inv_beta_s;

--- a/src/ui.cc
+++ b/src/ui.cc
@@ -787,29 +787,8 @@ void run_simulation(Set_ptrs &ptrs) {
 
     if(ibs) {
         assert(ptrs.ibs_ptr.get()!=nullptr && "PLEASE SET UP THE PARAMETERS FOR IBS RATE CALCULATION!");
-        int nu = ptrs.ibs_ptr->nu;
-        int nv = ptrs.ibs_ptr->nv;
-        int nz = ptrs.ibs_ptr->nz;
-        double log_c = ptrs.ibs_ptr->log_c;
-        double k = ptrs.ibs_ptr->coupling;
-//        double rx, ry, rz;
-        IBSModel model = ptrs.ibs_ptr->model;
-
-        if(model==IBSModel::MARTINI){
-            if (log_c>0) {
-                assert(nu>0 && nv>0 && "WRONG PARAMETER VALUE FOR IBS RATE CALCULATION!");
-                ibs_paras = new IBSParas(nu, nv, log_c);
-            }
-            else {
-                assert(nu>0 && nv>0 && nz>0 && "WRONG PARAMETER VALUE FOR IBS RATE CALCULATION!");
-                ibs_paras = new IBSParas(nu, nv, nz);
-                ibs_paras->set_log_c(log_c);
-            }
-        }
-        else if(model==IBSModel::BM) {
-            ibs_paras = new IBSParas(model);
-        }
-        if (k>0) ibs_paras->set_k(k);
+	if (!ibs_solver)
+		calculate_ibs(ptrs);
     }
 
     if (ibs && !ecool && dynamic_paras->model()==DynamicModel::PARTICLE) {

--- a/src/ui.cc
+++ b/src/ui.cc
@@ -804,7 +804,7 @@ void run_simulation(Set_ptrs &ptrs) {
         int nz = ptrs.ibs_ptr->nz;
         double log_c = ptrs.ibs_ptr->log_c;
         double k = ptrs.ibs_ptr->coupling;
-        double rx, ry, rz;
+//        double rx, ry, rz;
         IBSModel model = ptrs.ibs_ptr->model;
 
         if(model==IBSModel::MARTINI){


### PR DESCRIPTION
- I refactored some of the IBS code to make it more readable and extensible. My version combines IBSParams and the corresponding functions into a class IBSSolver with a purely virtual rate() method. The Martini and BM solvers implement this interface. I haven't touched the BM code as far as math and the internal data structure go, but my version of the Martini solver uses std::vectors to cache the computational results and has some speed optimizations in the loops. The changes improve the single-thread performance by about 30%. The data structure storing the intermediate results is also better suited for multithreading. Passing -fopenmp to gcc will turn on parallelization of the loop that iterates over the lattice, but the number of tasks is currently hardcoded. Performance on my six-core machine maxes out at 6 threads, speeding up my test input by another 30%. I have not measured the execution time of the f() method alone.

- The original code would sometimes crash depending on the compiler settings, the reason being that some non-void functions would return without a value, which is not allowed in C++ and gives unpredictable results even if the results are not used. These bugs have been fixed.

- If you run the original code with nz > 0 and log_c = 0 so that it performs the z integration, it will report use_log_c() == 1 after the initial IBS step for some reason. This could be really dangerous if the user doesn't notice it and gets a wrong result. Fixed as well.

I did some basic regression tests to make sure my changes don't affect the physics, but please double-check before blindly merging :)